### PR TITLE
Update xfce4-session.xml- FailsafeSessionName

### DIFF
--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
@@ -2,7 +2,7 @@
 
 <channel name="xfce4-session" version="1.0">
   <property name="general" type="empty">
-    <property name="FailsafeSessionName" type="string" value="Failsafe"/>
+    <property name="FailsafeSessionName" type="empty"/>
     <property name="SaveOnExit" type="bool" value="false"/>
   </property>
   <property name="sessions" type="empty">


### PR DESCRIPTION
Edited FailsafeSessionName

## Summary by Sourcery

Chores:
- Remove the `FailsafeSessionName` property from the xfce4-session configuration.