### PR TITLE
Update xfce4-desktop.xml Background settings edit

### DIFF
--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -15,7 +15,7 @@
   <property name="backdrop" type="empty">
     <property name="screen0" type="empty">
       <property name="monitor0" type="empty">
-        <property name="image-path" type="string" value="/usr/local/share/backgrounds/ghostbsd/Lake_View.jpg"/>
+        <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/Lake_View.jpg"/>
         <property name="image-style" type="int" value="5"/>
         <property name="image-show" type="bool" value="true"/>
       </property>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Switch from `image-path` to `last-image` property for storing the path to the default background image.