### PR TITLE
Update xfce4-session.xml Fix failsafe configuration

### DIFF
--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
@@ -7,7 +7,7 @@
   </property>
   <property name="sessions" type="empty">
     <property name="Failsafe" type="empty">
-      <property name="IsFailsafe" type="bool" value="true"/>
+      <property name="IsFailsafe" type="empty"/>
       <property name="Count" type="int" value="5"/>
       <property name="Client0_Command" type="array">
         <value type="string" value="xfwm4"/>


### PR DESCRIPTION
change line from 
<property name="IsFailsafe" type="bool" value="true"/> TO
<property name="IsFailsafe" type="empty"/>

## Summary by Sourcery

Bug Fixes:
- Set the "IsFailsafe" property to empty to ensure the failsafe session starts correctly.