### PR TITLE
Revert  failsafe configuration changes

### DIFF
--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
@@ -7,7 +7,7 @@
   </property>
   <property name="sessions" type="empty">
     <property name="Failsafe" type="empty">
-      <property name="IsFailsafe" type="empty"/>
+      <property name="IsFailsafe" type="bool" value="true"/>
       <property name="Count" type="int" value="5"/>
       <property name="Client0_Command" type="array">
         <value type="string" value="xfwm4"/>

--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml
@@ -2,7 +2,7 @@
 
 <channel name="xfce4-session" version="1.0">
   <property name="general" type="empty">
-    <property name="FailsafeSessionName" type="empty"/>
+    <property name="FailsafeSessionName" type="string" value="Failsafe"/>
     <property name="SaveOnExit" type="bool" value="false"/>
   </property>
   <property name="sessions" type="empty">


### PR DESCRIPTION
## Summary by Sourcery

Restore the failsafe session configuration to its default values.