### PR TITLE
Change XFCE desktop background images and settings

### DIFF
--- a/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -1,26 +1,33 @@
 <?xml version="1.1" encoding="UTF-8"?>
 
 <channel name="xfce4-desktop" version="1.0">
+  <property name="last-settings-migration-version" type="uint" value="1"/>
   <property name="backdrop" type="empty">
     <property name="screen0" type="empty">
-      <property name="monitor0" type="empty">
-        <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg"/>
-        <property name="image-style" type="int" value="3"/>
-        <property name="image-show" type="empty"/>
-      </property>
-      <property name="monitorDP-2" type="empty">
-	    <property name="workspace0" type="empty">
-	    <property name="image-style" type="int" value="3"/>
-          <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg"/>
-        </property>
-      </property>
-      <property name="monitorVGA-0" type="empty">
+      <property name="monitorLVDS-1" type="empty">
         <property name="workspace0" type="empty">
-	      <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg"/>
-	      <property name="image-style" type="int" value="3"/>
+          <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/lake-and-mountains.jpg"/>
         </property>
+      </property>
+      <property name="monitoreDP-1" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/lake-and-mountains.jpg"/>
+          </property>
+          </property>
+      <property name="monitorDisplayPort-0" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/lake-and-mountains.jpg"/>
+        </property>
+        </property>
+      <property name="screen0" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/lake-and-mountains.jpg"/>
       </property>
     </property>
   </property>
-  <property name="last-settings-migration-version" type="uint" value="1"/>
+  <property name="last" type="empty">
+    <property name="window-width" type="empty"/>
+    <property name="window-height" type="empty"/>
+  </property>
+  <property name="last-image" type="string" value="/usr/local/share/backgrounds/ghostbsd/lake-and-mountains.jpg"/>
 </channel>


### PR DESCRIPTION
Updated background images for multiple monitors and added last settings migration version.

## Summary by Sourcery

Update default XFCE desktop configuration for backgrounds and migration metadata.

New Features:
- Set specific default background image for multiple monitor types and the primary screen workspace.
- Define a top-level last-used background image property for the desktop configuration.

Enhancements:
- Move and standardize the last-settings-migration-version property in the desktop configuration.
- Add empty window size tracking properties for the last desktop configuration window.